### PR TITLE
feat(`playwright_repository`): allow reading playwright version from package.json file

### DIFF
--- a/examples/workspace/BUILD.bazel
+++ b/examples/workspace/BUILD.bazel
@@ -6,5 +6,29 @@ npm_link_all_packages(name = "node_modules")
 playwright_bin.playwright_test(
     name = "test",
     args = ["test"],
-    data = ["@playwright//:webkit"],
+    data = [
+        "playwright.config.ts",
+        "simple.e2e.ts",
+        "//:node_modules/@playwright/test",
+        "@playwright//:chromium-headless-shell",
+    ],
+    tags = ["requires-network"],
+    env = {
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright//:chromium-headless-shell)/../",
+    },
+)
+
+playwright_bin.playwright_test(
+    name = "test_2",
+    args = ["test"],
+    data = [
+        "playwright.config.ts",
+        "simple.e2e.ts",
+        "//:node_modules/@playwright/test",
+        "@playwright_2//:chromium-headless-shell",
+    ],
+    tags = ["requires-network"],
+    env = {
+        "PLAYWRIGHT_BROWSERS_PATH": "$(rootpath @playwright_2//:chromium-headless-shell)/../",
+    },
 )

--- a/examples/workspace/WORKSPACE.bazel
+++ b/examples/workspace/WORKSPACE.bazel
@@ -51,6 +51,12 @@ fetch_browsers()
 
 playwright_repository(
     name = "playwright",
-    playwright_version = "1.51.0",
+    playwright_version = "1.50.1",
+    user_workspace_name = "browsers_index",
+)
+
+playwright_repository(
+    name = "playwright_2",
+    playwright_version_from = "//:package.json",
     user_workspace_name = "browsers_index",
 )

--- a/examples/workspace/playwright.config.ts
+++ b/examples/workspace/playwright.config.ts
@@ -1,0 +1,5 @@
+import { defineConfig } from "@playwright/test";
+
+export default defineConfig({
+  testMatch: /.*\.e2e.ts/,
+});

--- a/examples/workspace/simple.e2e.ts
+++ b/examples/workspace/simple.e2e.ts
@@ -1,0 +1,6 @@
+import { test, expect } from "@playwright/test";
+
+test("basic test", async ({ page }) => {
+  await page.goto("https://bazel.build/");
+  await expect(page.getByText("{ Fast, Correct } — Choose two").first()).toBeVisible();
+});

--- a/playwright/repositories.bzl
+++ b/playwright/repositories.bzl
@@ -6,12 +6,73 @@ See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 
 load("//playwright/private:util.bzl", "get_browsers_json_path", "get_cli_path")
 
-_DOC = "Fetch external tools needed for playwright toolchain"
-_ATTRS = {
-    "playwright_version": attr.string(mandatory = False),
-    "browsers_json": attr.label(allow_single_file = True),
-    "user_workspace_name": attr.string(mandatory = True),
-}
+_PLAYWRIGHT_PACKAGE = "playwright"
+_PLAYWRIGHT_TEST_PACKAGE = "@playwright/test"
+_PLAYWRIGHT_PACKAGES = [_PLAYWRIGHT_PACKAGE, _PLAYWRIGHT_TEST_PACKAGE]
+
+def _find_playwright_version_in_deps(deps_dict):
+    for package in _PLAYWRIGHT_PACKAGES:
+        if package in deps_dict:
+            return deps_dict[package]
+    return None
+
+def _extract_playwright_version(package_json_data):
+    version = _find_playwright_version_in_deps(package_json_data.get("dependencies", {}))
+    if not version:
+        version = _find_playwright_version_in_deps(package_json_data.get("devDependencies", {}))
+
+    return version
+
+def _playwright_repo_impl(ctx):
+    if ctx.attr.playwright_version and ctx.attr.playwright_version_from:
+        fail("playwright_version and playwright_version_from cannot both be set")
+
+    if not ctx.attr.playwright_version and not ctx.attr.playwright_version_from:
+        fail("one of playwright_version or playwright_version_from must be set")
+
+    playwright_version = ctx.attr.playwright_version
+
+    if ctx.attr.playwright_version_from:
+        package_json_content = ctx.read(ctx.attr.playwright_version_from)
+        package_json_data = json.decode(package_json_content)
+        playwright_version = _extract_playwright_version(package_json_data)
+        if not playwright_version:
+            fail("playwright not found in dependencies or devDependencies")
+
+    result = ctx.execute(
+        [
+            get_cli_path(ctx),
+            "workspace",
+            "--browser-json-path",
+            get_browsers_json_path(ctx, playwright_version, ctx.attr.browsers_json),
+            "--workspace-name",
+            ctx.attr.user_workspace_name,
+        ],
+    )
+
+    if result.return_code != 0:
+        fail(ctx.attr.user_workspace_name, "workspace command failed", result.stdout, result.stderr)
+
+playwright_repository = repository_rule(
+    _playwright_repo_impl,
+    doc = "Fetch external tools needed for playwright toolchain",
+    attrs = {
+        "playwright_version": attr.string(
+            mandatory = False,
+            doc = "The version of playwright to install",
+        ),
+        "playwright_version_from": attr.label(
+            mandatory = False,
+            allow_single_file = [".json"],
+            doc = "The package.json file to use to find the version of playwright to install",
+        ),
+        "browsers_json": attr.label(
+            allow_single_file = True,
+            doc = "The browsers.json file to use. For example https://unpkg.com/playwright-core@1.51.0/browsers.json",
+        ),
+        "user_workspace_name": attr.string(mandatory = True),
+    },
+)
 
 def _define_browsers_impl(rctx):
     result = rctx.execute(
@@ -48,7 +109,6 @@ srcs = ["browser"],
 visibility = ["//visibility:public"],
 )
 \"\"\",
-            # integrity = repo.integrity_map.get(http_file_json["name"], None),
             urls = [
                 "https://playwright.azureedge.net/{path}",
                 "https://playwright-akamai.azureedge.net/{path}",
@@ -63,29 +123,8 @@ visibility = ["//visibility:public"],
     rctx.file("BUILD", "# no targets")
 
 define_browsers = repository_rule(
-    implementation = _define_browsers_impl, 
+    implementation = _define_browsers_impl,
     attrs = {
         "browsers_json": attr.label(allow_single_file = True),
     }
-)
-
-def _playwright_repo_impl(ctx):
-    result = ctx.execute(
-        [
-            get_cli_path(ctx),
-            "workspace",
-            "--browser-json-path",
-            get_browsers_json_path(ctx, ctx.attr.playwright_version, ctx.attr.browsers_json),
-            "--workspace-name",
-            ctx.attr.user_workspace_name,
-        ],
-    )
-
-    if result.return_code != 0:
-        fail(ctx.attr.user_workspace_name, "workspace command failed", result.stdout, result.stderr)
-
-playwright_repository = repository_rule(
-    _playwright_repo_impl,
-    doc = _DOC,
-    attrs = _ATTRS,
 )


### PR DESCRIPTION
Can be opened for review once #2 is merged

To prevent the divergence of playwright versions, we can load it from the package.json file:
```
playwright_repository(
    name = "playwright",
    playwright_version_from = "//:package.json",
    user_workspace_name = "browsers_index",
)
```