### PR TITLE
fix(get_cli_path): fix executable loading on Intel Macs

### DIFF
--- a/playwright/private/util.bzl
+++ b/playwright/private/util.bzl
@@ -33,7 +33,7 @@ def get_cli_path(ctx):
         Path to the browser workspace generator binary for the current platform
     """
     arch = "arm64"
-    if ctx.os.arch == "amd64":
+    if ctx.os.arch == "amd64" or ctx.os.arch == "x86_64":
         arch = "x86_64"
 
     platform = "unknown-linux-musl"


### PR DESCRIPTION
Currently, `rules_playwright` is failing to load on Intel Macs:
```
ERROR: .../external/rules_playwright/playwright/repositories.bzl:90:13: An error occurred during the fetch of repository 'browsers_index':
   Traceback (most recent call last):
        File ".../external/rules_playwright/playwright/repositories.bzl", line 90, column 13, in _define_browsers_impl
                fail("http-files command failed", result.stdout, result.stderr)
Error in fail: http-files command failed  src/main/tools/process-wrapper-legacy.cc:80: "execvp(.../external/rules_playwright/tools/release/artifacts/cli-arm64-apple-darwin, ...)": Bad CPU type in executable
ERROR: Error computing the main repository mapping: no such package '@@browsers_index//': http-files command failed  src/main/tools/process-wrapper-legacy.cc:80: "execvp(.../external/rules_playwright/tools/release/artifacts/cli-arm64-apple-darwin, ...)": Bad CPU type in executable
```

Intel macs use `x86_64` as arch instead of `amd64`. We need to support both of these patterns.

This fixes the repository loading on MacOS for Intel architecture.

```
DEBUG: /.../rule.bzl:4:10: ctx.os.arch:  x86_64
```