### PR TITLE
fix(playwright_repository): don't require version if JSON is specified

### DIFF
--- a/playwright/repositories.bzl
+++ b/playwright/repositories.bzl
@@ -28,8 +28,8 @@ def _playwright_repo_impl(ctx):
     if ctx.attr.playwright_version and ctx.attr.playwright_version_from:
         fail("playwright_version and playwright_version_from cannot both be set")
 
-    if not ctx.attr.playwright_version and not ctx.attr.playwright_version_from:
-        fail("one of playwright_version or playwright_version_from must be set")
+    if not ctx.attr.playwright_version and not ctx.attr.playwright_version_from and not ctx.attr.browsers_json:
+        fail("one of playwright_version or playwright_version_from or browsers_json must be set")
 
     playwright_version = ctx.attr.playwright_version
 


### PR DESCRIPTION
If users provide a `browsers_json`, don't require a version.