### PR TITLE
fix: support webkit symlinks when unzipped

### DIFF
--- a/playwright/private/unzip_browser.bzl
+++ b/playwright/private/unzip_browser.bzl
@@ -16,7 +16,7 @@ def _unzip_browser_impl(ctx):
         inputs = [ctx.file.browser],
         outputs = [output_dir],
         executable = ctx.executable._cli,
-        arguments = ["unzip", "--output-path", output_dir.path, "--input-path", ctx.file.browser.path],
+        arguments = ["--output-path", output_dir.path, "--input-path", ctx.file.browser.path]
     )
     return [
         DefaultInfo(files = depset([output_dir])),
@@ -37,7 +37,7 @@ unzip_browser = rule(
         ),
         "output_dir": attr.string(mandatory = True),
         "_cli": attr.label(
-            default = "//tools/release:cli",
+            default = "//tools/release:unzip_browser.sh"",
             allow_single_file = True,
             executable = True,
             cfg = "exec",

--- a/tools/release/BUILD.bazel
+++ b/tools/release/BUILD.bazel
@@ -67,3 +67,5 @@ native_binary(
     ),
     out = "cli",
 )
+
+exports_files(["unzip_browser.sh"])

--- a/tools/release/unzip_browser.sh
+++ b/tools/release/unzip_browser.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Check if required arguments are provided
+if [ "$#" -ne 4 ]; then
+    echo "Usage: $0 --output-path <output_dir> --input-path <zip_file>"
+    exit 1
+fi
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --output-path)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --input-path)
+            ZIP_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Unknown argument: $1"
+            exit 1
+            ;;
+    esac
+done
+
+# Create output directory if it doesn't exist
+mkdir -p "$OUTPUT_DIR"
+
+# Extract the zip file
+unzip -q "$ZIP_FILE" -d "$OUTPUT_DIR"
+
+# Ensure all files are executable
+find "$OUTPUT_DIR" -type f -exec chmod +x {} \;


### PR DESCRIPTION
Webkit ships with symlinks to the machine when
the zip file is opened. This fixes that until
the rust cli supports it

I understand this is non hermetic, but for now it works