### PR TITLE
Add configurable browser download URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,40 @@ playwright.repo(
 use_repo(playwright, "playwright")
 ```
 
+### Custom Browser Download URLs
+
+`browsers_download_urls` accepts either URL prefixes or URL templates containing `{path}`. Prefixes keep the historical behavior and append the browser archive path. Templates replace `{path}` with the resolved archive path, which is useful for internal mirrors:
+
+```python
+playwright.repo(
+    name = "playwright",
+    browsers_download_urls = [
+        "https://mirror.example.com/playwright/{path}",
+        "https://playwright.azureedge.net",
+    ],
+    playwright_version = "1.60.0",
+)
+```
+
+Use `browser_download_path_map` when Playwright's metadata points at an archive path that should be downloaded from a different path:
+
+```python
+playwright.repo(
+    name = "playwright",
+    browser_download_path_map = {
+        "builds/chromium/1223/chromium-linux.zip": "builds/cft/148.0.7778.96/linux64/chrome-linux64.zip",
+    },
+    browser_download_url_map = {
+        "builds/chromium/1223/chromium-linux.zip": [
+            "https://cdn.playwright.dev/{path}",
+        ],
+    },
+    playwright_version = "1.60.0",
+)
+```
+
+The same `browsers_download_urls`, `browser_download_path_map`, and `browser_download_url_map` attributes are available on `define_browsers` for WORKSPACE users.
+
 ## Usage with rules_js
 
 Here's an example of how to use `rules_playwright` with Playwright's test runner and `rules_js`:

--- a/playwright/BUILD.bazel
+++ b/playwright/BUILD.bazel
@@ -38,6 +38,7 @@ bzl_library(
     ],
     deps = [
         ":repositories",
+        "//playwright/private:download_urls",
         "@bazel_tools//tools/build_defs/repo:cache.bzl",
     ],
 )
@@ -56,6 +57,7 @@ bzl_library(
         "//docs:__subpackages__",
     ],
     deps = [
+        "//playwright/private:download_urls",
         "//playwright/private:known_browsers",
         "//playwright/private:util",
         "@bazel_tools//tools/build_defs/repo:http.bzl",

--- a/playwright/extensions.bzl
+++ b/playwright/extensions.bzl
@@ -11,6 +11,7 @@ effectively overriding the default named toolchain due to toolchain resolution p
 """
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("//playwright/private:download_urls.bzl", "DEFAULT_BROWSERS_DOWNLOAD_URLS", "browser_download_info")
 load("//playwright/private:known_browsers.bzl", "KNOWN_BROWSER_INTEGRITY")
 load("//playwright/private:util.bzl", "get_all_cli_paths", "get_browsers_json_path", "get_cli_path")
 load(":repositories.bzl", "playwright_repository")
@@ -24,12 +25,16 @@ Overriding the default is only permitted in the root module.
 """, default = _DEFAULT_NAME),
     "playwright_version": attr.string(doc = "Explicit version of playwright to download browsers.json from"),
     "browsers_download_urls": attr.string_list(
-      default = [
-        "https://playwright.azureedge.net",
-        "https://playwright-akamai.azureedge.net",
-        "https://playwright-verizon.azureedge.net",
-      ],
-      doc = "URLs to download playwright browsers from. Replace defaults if a mirror location is preferred.",
+        default = DEFAULT_BROWSERS_DOWNLOAD_URLS,
+        doc = "URLs to download playwright browsers from. Entries containing `{path}` are treated as URL templates; otherwise the browser archive path is appended.",
+    ),
+    "browser_download_path_map": attr.string_dict(
+        default = {},
+        doc = "Mapping from Playwright browser archive paths to replacement download paths.",
+    ),
+    "browser_download_url_map": attr.string_list_dict(
+        default = {},
+        doc = "Mapping from Playwright browser archive paths to replacement download URL templates.",
     ),
     "browsers_json": attr.label(doc = "Alternative to playwright_version. Skips downloading from unpkg", allow_single_file = True),
     "integrity_map": attr.string_dict(
@@ -82,18 +87,21 @@ def _extension_impl(module_ctx):
             for http_file_json in json.decode(result.stdout):
                 browser_name = http_file_json["name"]
                 path = http_file_json["path"]
+                download = browser_download_info(path, repo.browsers_download_urls, repo.browser_download_path_map, repo.browser_download_url_map)
                 integrity = repo.integrity_map.get(browser_name, None)
                 if not integrity:
-                    integrity = repo.integrity_path_map.get(path, None)
+                    integrity = repo.integrity_path_map.get(download.path, None)
+                    if not integrity:
+                        integrity = repo.integrity_path_map.get(path, None)
+                    if not integrity:
+                        integrity = KNOWN_BROWSER_INTEGRITY.get(download.path, None)
                     if not integrity:
                         integrity = KNOWN_BROWSER_INTEGRITY.get(path, None)
-
-                urls = [url + "/" + path for url in repo.browsers_download_urls]
 
                 http_file(
                     name = browser_name,
                     integrity = integrity,
-                    urls = urls,
+                    urls = download.urls,
                 )
 
             # Step 2: generate repository which references said http_files

--- a/playwright/private/BUILD.bazel
+++ b/playwright/private/BUILD.bazel
@@ -1,9 +1,21 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load(":download_urls_test.bzl", "download_urls_test_suite")
 
 exports_files(
     glob(["*.bzl"]),
     visibility = ["//docs:__pkg__"],
 )
+
+bzl_library(
+    name = "download_urls",
+    srcs = ["download_urls.bzl"],
+    visibility = [
+        "//docs:__subpackages__",
+        "//playwright:__subpackages__",
+    ],
+)
+
+download_urls_test_suite(name = "download_urls_test")
 
 bzl_library(
     name = "integrity_map",

--- a/playwright/private/download_urls.bzl
+++ b/playwright/private/download_urls.bzl
@@ -1,0 +1,24 @@
+"""Helpers for browser archive download URLs."""
+
+DEFAULT_BROWSERS_DOWNLOAD_URLS = [
+    "https://playwright.azureedge.net",
+    "https://playwright-akamai.azureedge.net",
+    "https://playwright-verizon.azureedge.net",
+]
+
+_PATH_PLACEHOLDER = "{path}"
+
+def browser_download_info(path, browsers_download_urls, browser_download_path_map, browser_download_url_map):
+    """Returns the resolved archive path and URLs for a Playwright browser archive."""
+    download_path = browser_download_path_map.get(path, path)
+    download_url_templates = browser_download_url_map.get(path, browser_download_url_map.get(download_path, browsers_download_urls))
+    return struct(
+        path = download_path,
+        urls = [_format_browser_download_url(url, download_path) for url in download_url_templates],
+    )
+
+def _format_browser_download_url(url, path):
+    if _PATH_PLACEHOLDER in url:
+        return url.replace(_PATH_PLACEHOLDER, path)
+
+    return "{}/{}".format(url, path)

--- a/playwright/private/download_urls_test.bzl
+++ b/playwright/private/download_urls_test.bzl
@@ -1,0 +1,96 @@
+"""Tests for browser archive download URL helpers."""
+
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load(":download_urls.bzl", "browser_download_info")
+
+def _url_templates_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    download = browser_download_info(
+        "builds/chromium/1223/chromium-linux.zip",
+        [
+            "https://cache.example.com/playwright/{path}",
+            "https://playwright.azureedge.net",
+        ],
+        {},
+        {},
+    )
+
+    asserts.equals(env, "builds/chromium/1223/chromium-linux.zip", download.path)
+    asserts.equals(
+        env,
+        [
+            "https://cache.example.com/playwright/builds/chromium/1223/chromium-linux.zip",
+            "https://playwright.azureedge.net/builds/chromium/1223/chromium-linux.zip",
+        ],
+        download.urls,
+    )
+
+    return unittest.end(env)
+
+_url_templates_test = unittest.make(_url_templates_test_impl)
+
+def _path_map_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    download = browser_download_info(
+        "builds/chromium/1223/chromium-headless-shell-linux.zip",
+        ["https://cdn.playwright.dev/{path}"],
+        {
+            "builds/chromium/1223/chromium-headless-shell-linux.zip": "builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip",
+        },
+        {},
+    )
+
+    asserts.equals(
+        env,
+        "builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip",
+        download.path,
+    )
+    asserts.equals(
+        env,
+        [
+            "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-headless-shell-linux64.zip",
+        ],
+        download.urls,
+    )
+
+    return unittest.end(env)
+
+_path_map_test = unittest.make(_path_map_test_impl)
+
+def _url_map_test_impl(ctx):
+    env = unittest.begin(ctx)
+
+    download = browser_download_info(
+        "builds/chromium/1223/chromium-linux.zip",
+        ["https://playwright.azureedge.net"],
+        {
+            "builds/chromium/1223/chromium-linux.zip": "builds/cft/148.0.7778.96/linux64/chrome-linux64.zip",
+        },
+        {
+            "builds/chromium/1223/chromium-linux.zip": [
+                "https://cdn.playwright.dev/{path}",
+            ],
+        },
+    )
+
+    asserts.equals(
+        env,
+        [
+            "https://cdn.playwright.dev/builds/cft/148.0.7778.96/linux64/chrome-linux64.zip",
+        ],
+        download.urls,
+    )
+
+    return unittest.end(env)
+
+_url_map_test = unittest.make(_url_map_test_impl)
+
+def download_urls_test_suite(name):
+    unittest.suite(
+        name,
+        _url_templates_test,
+        _path_map_test,
+        _url_map_test,
+    )

--- a/playwright/repositories.bzl
+++ b/playwright/repositories.bzl
@@ -4,6 +4,7 @@ These are needed for local dev, and users must install them as well.
 See https://docs.bazel.build/versions/main/skylark/deploying.html#dependencies
 """
 
+load("//playwright/private:download_urls.bzl", "DEFAULT_BROWSERS_DOWNLOAD_URLS", "browser_download_info")
 load("//playwright/private:known_browsers.bzl", "KNOWN_BROWSER_INTEGRITY")
 load("//playwright/private:util.bzl", "get_all_cli_paths", "get_browsers_json_path", "get_cli_path")
 
@@ -129,13 +130,17 @@ def _define_browsers_impl(rctx):
 
     for http_file_json in json.decode(result.stdout):
         path = http_file_json["path"]
+        download = browser_download_info(path, rctx.attr.browsers_download_urls, rctx.attr.browser_download_path_map, rctx.attr.browser_download_url_map)
         integrity_attr = ""
-        if path in integrity_map:
-            integrity_attr = 'integrity = "{}",\n'.format(integrity_map[path])
+        integrity = integrity_map.get(download.path, None)
+        if not integrity:
+            integrity = integrity_map.get(path, None)
+        if integrity:
+            integrity_attr = 'integrity = "{}",\n'.format(integrity)
 
         urls_attr = "urls = [\n"
-        for url in rctx.attr.browsers_download_urls:
-            urls_attr = urls_attr + "\"{}/{}\",\n".format(url, path)
+        for url in download.urls:
+            urls_attr = urls_attr + "\"{}\",\n".format(url)
         urls_attr = urls_attr + "],"
 
         result_build.append("""\
@@ -162,12 +167,16 @@ define_browsers = repository_rule(
     attrs = {
         "browsers_json": attr.label(allow_single_file = True),
         "browsers_download_urls": attr.string_list(
-          default = [
-            "https://playwright.azureedge.net",
-            "https://playwright-akamai.azureedge.net",
-            "https://playwright-verizon.azureedge.net",
-          ],
-          doc = "URLs to download playwright browsers from. Replace defaults if a mirror location is preferred.",
+            default = DEFAULT_BROWSERS_DOWNLOAD_URLS,
+            doc = "URLs to download playwright browsers from. Entries containing `{path}` are treated as URL templates; otherwise the browser archive path is appended.",
+        ),
+        "browser_download_path_map": attr.string_dict(
+            doc = "Mapping from Playwright browser archive paths to replacement download paths.",
+            default = {},
+        ),
+        "browser_download_url_map": attr.string_list_dict(
+            doc = "Mapping from Playwright browser archive paths to replacement download URL templates.",
+            default = {},
         ),
         "browser_integrity": attr.string_dict(
             doc = "A dictionary of browser names to their integrity hashes",


### PR DESCRIPTION
## Why

Some Playwright browser archives may need to be fetched from a different path or mirror than the path reported in Playwright metadata. Today, users have to work around that outside `rules_playwright`, usually with downloader rewrites.

This adds first-class configuration for that case.

## What changed

- Allow `browsers_download_urls` entries to use `{path}` URL templates while preserving the existing prefix behavior.
- Add `browser_download_path_map` to remap browser archive paths before download URL generation and integrity lookup.
- Add `browser_download_url_map` for per-path download URL templates.
- Share the behavior between the Bzlmod extension and `define_browsers`.
- Add Starlark unit tests for URL templates, path mapping, and per-path URL overrides.
- Document the new configuration in the README.

## Validation

- `bazel test //playwright/private:download_urls_test`
- `bazel build //playwright:extensions //playwright:repositories //playwright/private:download_urls`
- `buildifier -mode=check playwright/BUILD.bazel playwright/extensions.bzl playwright/private/BUILD.bazel playwright/private/download_urls.bzl playwright/private/download_urls_test.bzl playwright/repositories.bzl`